### PR TITLE
Allow PropertyChangeCallbacks with 1 argument

### DIFF
--- a/src/dualsense_controller/api/typedef.py
+++ b/src/dualsense_controller/api/typedef.py
@@ -5,4 +5,4 @@ _PrChCb0 = Callable[[], None]
 _PrChCb1 = Callable[[PropertyType], None]
 _PrChCb2 = Callable[[PropertyType, int], None]
 _PrChCb3 = Callable[[PropertyType, PropertyType, int], None]
-PropertyChangeCallback = _PrChCb0 | _PrChCb0 | _PrChCb2 | _PrChCb3
+PropertyChangeCallback = _PrChCb0 | _PrChCb1 | _PrChCb2 | _PrChCb3


### PR DESCRIPTION
This seems like a typo since _PrChCb0 is listed twice