### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ For use the controller in Python without root privileges add the udev rule.
 sudo cp res/70-dualsense.rules /etc/udev/rules.d
 ```
 
-or create a file `/etd/udev/rules.d/70-dualsense.rules` with following content.
+or create a file `/etc/udev/rules.d/70-dualsense.rules` with following content.
 
 ```
 # USB


### PR DESCRIPTION
Fixed line for udev rules 
or create a file /etd/udev/rules.d/70-dualsense.rules with following content.
to 
or create a file /etc/udev/rules.d/70-dualsense.rules with following content. Validated to work as well
